### PR TITLE
[MOSIP-35396] Added dependencies required for the Java 21 beta release in artifactory.

### DIFF
--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -51,6 +51,9 @@ ENV base_path=/usr/share/nginx/html/artifactory
 # environment variable for Biosdk client Zip path
 ENV biosdk_client_zip_path=${base_path}/libs-release-local/biosdk/mock/0.9
 
+# environment variable for java 11 Biosdk client Zip path
+ENV biosdk_client_zip_java11_path=${base_path}/libs-release-local/biosdk/mock/0.9/java11
+
 # environment variable for Demosdk Zip path
 ENV demosdk_zip_path=${base_path}/libs-release-local/demosdk/default/
 
@@ -126,11 +129,13 @@ ENV version=1.2.1-SNAPSHOT
 ENV idp_auth_wrapper_version=0.0.1-SNAPSHOT
 
 # Create all the jar, i18n & theme paths.
-RUN mkdir -p ${biosdk_client_zip_path}/biosdk-client ${demosdk_zip_path}/demosdk ${biosdk_lib_zip_path}/biosdk-lib ${cache_path} ${ida_sh_path} ${hsm_client_path} ${mosip_plugins_zip_path} ${kernel_jar_path} ${test_jar_path} ${idobject_jar_path} ${regproc_jar_path} ${sdk_path} ${image_compressor_path}/image-compressor ${icu4j_jar_path} ${clamav_path} ${i18n_zip_path} ${theme_zip_path} ${child_auth_filter_jar_path} ${base_path}/libs-release-local/reg-client ${scripts_path} ${master_template_path} ${idp_auth_wrapper_lib_zip_path} ${esignet_wrapper_lib_zip_path}/esignet-wrapper ${certify_plugin_zip_path}/certify-plugin ${registration_api_impl_zip_path}/registration-api-impl
+RUN mkdir -p ${biosdk_client_zip_java11_path}/biosdk-client/ ${biosdk_client_zip_path}/biosdk-client ${demosdk_zip_path}/demosdk ${biosdk_lib_zip_path}/biosdk-lib ${cache_path} ${ida_sh_path} ${hsm_client_path} ${mosip_plugins_zip_path} ${kernel_jar_path} ${test_jar_path} ${idobject_jar_path} ${regproc_jar_path} ${sdk_path} ${image_compressor_path}/image-compressor ${icu4j_jar_path} ${clamav_path} ${i18n_zip_path} ${theme_zip_path} ${child_auth_filter_jar_path} ${base_path}/libs-release-local/reg-client ${scripts_path} ${master_template_path} ${idp_auth_wrapper_lib_zip_path} ${esignet_wrapper_lib_zip_path}/esignet-wrapper ${certify_plugin_zip_path}/certify-plugin ${registration_api_impl_zip_path}/registration-api-impl
 
 # Copy all the respective jars to the location
 
 COPY /src/sdk/biosdk/install.sh ${biosdk_client_zip_path}/biosdk-client/
+
+COPY /src/sdk/biosdk/install.sh ${biosdk_client_zip_java11_path}/biosdk-client/
 
 COPY /src/sdk/demosdk/install.sh ${demosdk_zip_path}/demosdk/
 

--- a/artifacts/configure.sh
+++ b/artifacts/configure.sh
@@ -16,6 +16,12 @@ zip -r -j ${biosdk_client_zip_path}/biosdk-client.zip ${biosdk_client_zip_path}/
 rm -rf ${biosdk_client_zip_path}/biosdk-client
 echo biosdk client zip creation completed
 
+# This is added temporary and will be removed dependent modules are migrated to java 21
+echo biosdk client zip java11 creation started
+zip -r -j ${biosdk_client_zip_java11_path}/biosdk-client.zip ${biosdk_client_zip_java11_path}/biosdk-client/*
+rm -rf ${biosdk_client_zip_java11_path}/biosdk-client
+echo biosdk client zip creation completed
+
 echo biosdk-lib zip creation started
 zip -r -j ${biosdk_lib_zip_path}/biosdk-lib.zip ${biosdk_lib_zip_path}/biosdk-lib/*
 rm -rf ${biosdk_lib_zip_path}/biosdk-lib

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -128,6 +128,12 @@
 		<biosdk-client.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/mock/0.9/biosdk-client</biosdk-client.location>
 		<biosdk-client-lib.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/biosdk-lib</biosdk-client-lib.location>
 		<biosdk-client.fileName>biosdk-client-jar-with-dependencies.jar</biosdk-client.fileName>
+		<!-- This is added temporary and will be removed dependent modules are migrated to java 21 -->
+		<biosdk-client-java-11.version>1.2.0.1</biosdk-client-java-11.version>
+		<biosdk-client-java-11.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/mock/0.9/java11/biosdk-client</biosdk-client-java-11.location>
+		<biosdk-client-lib-java-11.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/java11/biosdk-lib</biosdk-client-lib-java-11.location>
+		<biosdk-client-java-11.fileName>biosdk-client-jar-with-dependencies.jar</biosdk-client-java-11.fileName>
+
 		<!-- demosdk-client -->
 		<demosdk-client.version>1.2.0.1</demosdk-client.version>
 		<demosdk-client.location>/usr/share/nginx/html/artifactory/libs-release-local/demosdk/default/demosdk</demosdk-client.location>
@@ -328,6 +334,16 @@
 					<version>${biosdk-client.version}</version>
 					 <outputDirectory>${biosdk-client.location}</outputDirectory> 
 					<destFileName>${biosdk-client.fileName}</destFileName>
+					<classifier>jar-with-dependencies</classifier>
+					<type>jar</type>
+				</artifactItem>
+				<!-- This is added temporary and will be removed dependent modules are migrated to java 21 -->
+				<artifactItem>
+					<groupId>io.mosip.biosdk</groupId>
+					<artifactId>biosdk-client</artifactId>
+					<version>${biosdk-client-java-11.version}</version>
+					<outputDirectory>${biosdk-client-java-11.location}</outputDirectory>
+					<destFileName>${biosdk-client-java-11.fileName}</destFileName>
 					<classifier>jar-with-dependencies</classifier>
 					<type>jar</type>
 				</artifactItem>


### PR DESCRIPTION
[MOSIP-35396] Added dependencies required for the Java 21 beta release in artifactory.

[MOSIP-35396]: https://mosip.atlassian.net/browse/MOSIP-35396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ