### PR TITLE
[MOSIP-35396] Added dependencies required for the Java 21 beta release in artifactory.

### DIFF
--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -93,7 +93,8 @@
 		<kernel-transliteration-java-11.fileName>kernel-transliteration-icu4j.jar</kernel-transliteration-java-11.fileName>
 
 		<!-- kernel-smsserviceprovider-->
-		<kernel-smsserviceprovider.version>1.2.0.2</kernel-smsserviceprovider.version>
+		<!-- This is added temporary and need to change with release branch -->
+		<kernel-smsserviceprovider.version>1.2.1-SNAPSHOT</kernel-smsserviceprovider.version>
 		<kernel-smsserviceprovider.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</kernel-smsserviceprovider.location>
 		<kernel-smsserviceprovider.fileName>kernel-smsserviceprovider-msg91.jar</kernel-smsserviceprovider.fileName>
 		<!-- kernel-ref-idobjectvalidator -->


### PR DESCRIPTION
[MOSIP-35396] Added dependencies required for the Java 21 beta release in artifactory.

[MOSIP-35396]: https://mosip.atlassian.net/browse/MOSIP-35396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ