### PR TITLE
[DSD-6413] update certify-mock-plugin version to 0.3.0-SNAPSHOT

### DIFF
--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -218,7 +218,7 @@
 
 		<!-- certify mock plugin -->
 		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
-		<certify-mock-plugin.version>0.2.1-SNAPSHOT</certify-mock-plugin.version>
+		<certify-mock-plugin.version>0.3.0-SNAPSHOT</certify-mock-plugin.version>
 		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
 		
 		<!-- esignet IDA wrapper -->


### PR DESCRIPTION
certify-mock-plugin 0.3.0-SNAPSHOT version supports mobile driving license issuance