### PR TITLE
Docker build fix [MOSIP-44274]

### DIFF
--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -28,8 +28,8 @@ apt-get update -y && \
 apt-get install -y --no-install-recommends unzip wget zip openjdk-11-jdk && \
 groupadd -g ${container_user_gid} ${container_user_group} &&\
 rm -rf /var/lib/apt/lists/* &&\
-wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz &&\
-tar -xzf apache-maven-3.8.8-bin.tar.gz && mv apache-maven-3.8.8 /usr/local/maven && rm apache-maven-3.8.8-bin.tar.gz &&\
+wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz &&\
+tar -xzf apache-maven-3.8.9-bin.tar.gz && mv apache-maven-3.8.9 /usr/local/maven && rm apache-maven-3.8.9-bin.tar.gz &&\
 useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
 && mkdir -p /var/run/nginx /var/tmp/nginx \
 && chown -R ${container_user}:${container_user} /usr/share/nginx /var/run/nginx /var/tmp/nginx

--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -28,8 +28,8 @@ apt-get update -y && \
 apt-get install -y --no-install-recommends unzip wget zip openjdk-11-jdk && \
 groupadd -g ${container_user_gid} ${container_user_group} &&\
 rm -rf /var/lib/apt/lists/* &&\
-wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz &&\
-tar -xzf apache-maven-3.8.9-bin.tar.gz && mv apache-maven-3.8.9 /usr/local/maven && rm apache-maven-3.8.9-bin.tar.gz &&\
+wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz &&\
+tar -xzf apache-maven-3.9.15-bin.tar.gz && mv apache-maven-3.9.15 /usr/local/maven && rm apache-maven-3.9.15-bin.tar.gz &&\
 useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
 && mkdir -p /var/run/nginx /var/tmp/nginx \
 && chown -R ${container_user}:${container_user} /usr/share/nginx /var/run/nginx /var/tmp/nginx

--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -51,16 +51,11 @@ ENV base_path=/usr/share/nginx/html/artifactory
 # environment variable for Biosdk client Zip path
 ENV biosdk_client_zip_path=${base_path}/libs-release-local/biosdk/mock/0.9
 
-# environment variable for Biosdk client Zip path
-ENV biosdk_client_zip_java21_path=${base_path}/libs-release-local/biosdk/mock/0.9/java21
-
 # environment variable for Demosdk Zip path
 ENV demosdk_zip_path=${base_path}/libs-release-local/demosdk/default/
 
 # environment variable for Biosdk lib Zip path
 ENV biosdk_lib_zip_path=${base_path}/libs-release-local/biosdk/
-
-ENV biosdk_lib_zip_java21_path=${base_path}/libs-release-local/biosdk/java21/
 
 # environment variable for Biosdk lib Zip path
 ENV jpegsdk_lib_zip_path=${base_path}/libs-release-local/jpeg-sdk/
@@ -79,9 +74,6 @@ ENV mosip_plugins_zip_path=${base_path}/libs-release-local/mosip-plugins
 
 # environment valiable for sdk jar
 ENV sdk_path=${base_path}/libs-release-local/mock-sdk/1.1.5/
-
-# environment valiable for sdk jar
-ENV jpeg_sdk_path=${base_path}/libs-release-local/jpeg-mock-sdk/1.1.5/
 
 # environment valiable for image-compressor jar
 ENV image_compressor_path=${base_path}/libs-release-local/compressor/
@@ -143,24 +135,16 @@ ENV version=1.2.1-SNAPSHOT
 ENV idp_auth_wrapper_version=0.0.1-SNAPSHOT
 
 # Create all the jar, i18n & theme paths.
-RUN mkdir -p ${biosdk_client_zip_java21_path}/biosdk-client/ ${biosdk_client_zip_path}/biosdk-client ${demosdk_zip_path}/demosdk ${biosdk_lib_zip_path}/biosdk-lib ${biosdk_lib_zip_java21_path}/biosdk-lib ${cache_path} ${ida_sh_path} ${hsm_client_path} ${mosip_plugins_zip_path} ${kernel_jar_path} ${test_jar_path} ${idobject_jar_path} ${regproc_jar_path} ${sdk_path} ${image_compressor_path}/image-compressor ${icu4j_jar_path} ${icu4j_jar_path}/java21 ${clamav_path} ${i18n_zip_path} ${theme_zip_path} ${image_zip_path} ${child_auth_filter_jar_path} ${base_path}/libs-release-local/reg-client ${scripts_path} ${master_template_path} ${pdf_generator_path} ${jpeg_sdk_path} ${jpegsdk_lib_zip_path}/jpeg-sdk-lib/ ${idp_auth_wrapper_lib_zip_path} ${esignet_wrapper_lib_zip_path}/esignet-wrapper ${certify_plugin_zip_path}/certify-plugin ${registration_api_impl_zip_path}/registration-api-impl ${esignet_wrapper_lib_zip_path}/esignet-plugins
+RUN mkdir -p ${biosdk_client_zip_path}/biosdk-client ${demosdk_zip_path}/demosdk ${biosdk_lib_zip_path}/biosdk-lib ${cache_path} ${ida_sh_path} ${hsm_client_path} ${mosip_plugins_zip_path} ${kernel_jar_path} ${test_jar_path} ${idobject_jar_path} ${regproc_jar_path} ${sdk_path} ${image_compressor_path}/image-compressor ${icu4j_jar_path} ${clamav_path} ${i18n_zip_path} ${theme_zip_path} ${image_zip_path} ${child_auth_filter_jar_path} ${base_path}/libs-release-local/reg-client ${scripts_path} ${master_template_path} ${pdf_generator_path} ${idp_auth_wrapper_lib_zip_path} ${esignet_wrapper_lib_zip_path}/esignet-wrapper ${certify_plugin_zip_path}/certify-plugin ${registration_api_impl_zip_path}/registration-api-impl
 # Copy all the respective jars to the location
 
 COPY /src/sdk/biosdk/install.sh ${biosdk_client_zip_path}/biosdk-client/
-
-COPY /src/sdk/biosdk/install.sh ${biosdk_client_zip_java21_path}/biosdk-client/
 
 COPY /src/sdk/demosdk/install.sh ${demosdk_zip_path}/demosdk/
 
 COPY /src/deployment/docker/id-authentication/* ${ida_sh_path}/
 
 COPY /src/hsm/client.zip ${hsm_client_path}/
-
-COPY /src/hsm/client-alpine.zip ${hsm_client_path}/
-
-COPY /src/hsm/client-ubuntu.zip ${hsm_client_path}/
-
-COPY /src/hsm/client-21.zip ${hsm_client_path}/
 
 COPY /src/mosip-plugins/sign-in-with-esignet/sign-in-with-esignet.zip ${mosip_plugins_zip_path}/
 
@@ -174,8 +158,6 @@ COPY /src/i18n/admin-entity-spec-bundle/*  ${work_dir}/admin-entity-spec-bundle/
 
 COPY /src/i18n/admin-i18n-bundle/*  ${work_dir}/admin-i18n-bundle/
 
-COPY /src/i18n/resident-i18n-bundle/*  ${work_dir}/resident-i18n-bundle/
-
 COPY /src/i18n/pmp-entity-spec-bundle/*  ${work_dir}/pmp-entity-spec-bundle/
 
 COPY /src/i18n/pmp-i18n-bundle/*  ${work_dir}/pmp-i18n-bundle/
@@ -185,8 +167,6 @@ COPY /src/i18n/pre-registration-i18n-bundle/*  ${work_dir}/pre-registration-i18n
 COPY /src/master-templates/* ${work_dir}/master-templates/
 
 COPY /src/pdf-generator/* ${work_dir}/pdf-generator/
-
-COPY /src/i18n/idp-i18n-bundle/*  ${work_dir}/idp-i18n-bundle/
 
 COPY /src/i18n/oidc-demo-i18n-bundle/*  ${work_dir}/oidc-demo-i18n-bundle/
 

--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -105,11 +105,11 @@ ENV image_zip_path=${base_path}/libs-release-local/image
 # environment variable for idp auth wrapper zip path
 ENV idp_auth_wrapper_lib_zip_path=${base_path}/libs-release-local/idp/idp-auth-wrapper
 
+# environment variable for certify plugins zip path
+ENV certify_plugin_zip_path=${base_path}/libs-release-local/certify
+
 # environment variable for esignet wrappers zip path
 ENV esignet_wrapper_lib_zip_path=${base_path}/libs-release-local/esignet
-
-#environment variable for certify plugins zip path
-ENV certify_plugin_zip_path=${base_path}/libs-release-local/certify
 
 # environment variable for Clamav dependency
 ENV clamav_path=${base_path}/libs-release-local/clamav
@@ -121,9 +121,6 @@ ENV regclient_jar_path=${base_path}/libs-release-local
 
 ENV master_template_path=${base_path}/libs-release-local/master-templates
 
-# environment variable
-ENV pdf_generator_path=${base_path}/libs-release-local/pdf-generator
-
 # environment variable for child auth filter jar path
 ENV child_auth_filter_jar_path=${base_path}/libs-release-local/io/mosip/authentication/authentication-ref-impl
 
@@ -134,8 +131,12 @@ ENV scripts_path=/home/mosip/scripts
 ENV version=1.2.1-SNAPSHOT
 ENV idp_auth_wrapper_version=0.0.1-SNAPSHOT
 
+#environment variable for pdf generator
+ENV pdf_generator_path=${base_path}/libs-release-local/pdf-generator
+
 # Create all the jar, i18n & theme paths.
 RUN mkdir -p ${biosdk_client_zip_path}/biosdk-client ${demosdk_zip_path}/demosdk ${biosdk_lib_zip_path}/biosdk-lib ${cache_path} ${ida_sh_path} ${hsm_client_path} ${mosip_plugins_zip_path} ${kernel_jar_path} ${test_jar_path} ${idobject_jar_path} ${regproc_jar_path} ${sdk_path} ${image_compressor_path}/image-compressor ${icu4j_jar_path} ${clamav_path} ${i18n_zip_path} ${theme_zip_path} ${image_zip_path} ${child_auth_filter_jar_path} ${base_path}/libs-release-local/reg-client ${scripts_path} ${master_template_path} ${pdf_generator_path} ${idp_auth_wrapper_lib_zip_path} ${esignet_wrapper_lib_zip_path}/esignet-wrapper ${certify_plugin_zip_path}/certify-plugin ${registration_api_impl_zip_path}/registration-api-impl
+
 # Copy all the respective jars to the location
 
 COPY /src/sdk/biosdk/install.sh ${biosdk_client_zip_path}/biosdk-client/
@@ -166,8 +167,6 @@ COPY /src/i18n/pre-registration-i18n-bundle/*  ${work_dir}/pre-registration-i18n
 
 COPY /src/master-templates/* ${work_dir}/master-templates/
 
-COPY /src/pdf-generator/* ${work_dir}/pdf-generator/
-
 COPY /src/i18n/oidc-demo-i18n-bundle/*  ${work_dir}/oidc-demo-i18n-bundle/
 
 COPY /src/i18n/mock-relying-party-i18n-bundle/*  ${work_dir}/mock-relying-party-i18n-bundle/
@@ -187,6 +186,9 @@ COPY /src/theme/esignet-signup-theme/* ${work_dir}/esignet-signup-theme/
 COPY /src/jre/* ${regclient_jar_path}/
 
 COPY /src/icu4j/* ${icu4j_jar_path}/
+
+COPY /src/pdf-generator/* ${work_dir}/pdf-generator/
+
 
 COPY /src/auth/* ${regproc_jar_path}/
 

--- a/artifacts/configure.sh
+++ b/artifacts/configure.sh
@@ -5,8 +5,8 @@ set -e
 # This scripts performs multiple commands to set up the libraries inside the artifactory server docker.
 # Activies performed are listed as below
 # 1. biosdk-client zip creation
-# 2. jpeg-sdk-lib zip creation
-# 3. biosdk-lib zip ceation
+# 2. biosdk-lib zip creation
+# 3. image-compressor zip ceation
 # 4. demosdk-lib zip creation
 # 5. Create resources zip for reg-client
 # 6. Create i18n and entity-spec bundles zip files for all the required modules
@@ -17,24 +17,9 @@ zip -r -j ${biosdk_client_zip_path}/biosdk-client.zip ${biosdk_client_zip_path}/
 rm -rf ${biosdk_client_zip_path}/biosdk-client
 echo biosdk client zip creation completed
 
-echo biosdk client zip java21 creation started
-zip -r -j ${biosdk_client_zip_java21_path}/biosdk-client.zip ${biosdk_client_zip_java21_path}/biosdk-client/*
-rm -rf ${biosdk_client_zip_java21_path}/biosdk-client
-echo biosdk client zip creation completed
-
-echo jpeg-sdk-lib zip creation started
-zip -r -j ${jpegsdk_lib_zip_path}/jpeg-sdk-lib.zip ${jpegsdk_lib_zip_path}/jpeg-sdk-lib/*
-rm -rf ${jpegsdk_lib_zip_path}/jpeg-sdk-lib
-echo jpeg-sdk-lib zip creation completed
-
 echo biosdk-lib zip creation started
 zip -r -j ${biosdk_lib_zip_path}/biosdk-lib.zip ${biosdk_lib_zip_path}/biosdk-lib/*
 rm -rf ${biosdk_lib_zip_path}/biosdk-lib
-echo biosdk-lib zip creation completed
-
-echo biosdk-lib java21 zip creation started
-zip -r -j ${biosdk_lib_zip_java21_path}/biosdk-lib.zip ${biosdk_lib_zip_java21_path}/biosdk-lib/*
-rm -rf ${biosdk_lib_zip_java21_path}/biosdk-lib
 echo biosdk-lib zip creation completed
 
 echo image-compressor zip creation started
@@ -57,11 +42,6 @@ zip -r -j ${certify_plugin_zip_path}/certify-plugin.zip ${certify_plugin_zip_pat
 rm -rf ${certify_plugin_zip_path}/certify-plugin
 echo certify-plugin zip creation completed
 
-echo esignet-plugins zip creation started
-zip -r -j ${esignet_wrapper_lib_zip_path}/esignet-plugins.zip ${esignet_wrapper_lib_zip_path}/esignet-plugins/*
-rm -rf ${esignet_wrapper_lib_zip_path}/esignet-plugins
-echo esignet-plugins zip creation completed
-
 echo Creating resources.zip file for all the resources provided
 zip -r -j ${base_path}/libs-release-local/reg-client/resources.zip ${work_dir}/resources
 rm -rf ${work_dir}/resources
@@ -74,20 +54,17 @@ rm -rf ${work_dir}/admin-entity-spec-bundle ${work_dir}/pmp-entity-spec-bundle
 echo spec-bundle zip creation completed
 
 echo i18n-bundles zip creation for all the mentioned modules started
-zip -r -j ${i18n_zip_path}/admin-i18n-bundle.zip ${work_dir}/admin-i18n-bundle/* 
+zip -r -j ${i18n_zip_path}/admin-i18n-bundle.zip ${work_dir}/admin-i18n-bundle/*
 zip -r -j ${i18n_zip_path}/pmp-i18n-bundle.zip ${work_dir}/pmp-i18n-bundle/*
 zip -r -j ${i18n_zip_path}/pre-registration-i18n-bundle.zip ${work_dir}/pre-registration-i18n-bundle/*
 zip -r -j ${i18n_zip_path}/oidc-demo-i18n-bundle.zip ${work_dir}/oidc-demo-i18n-bundle/*
-zip -r -j ${i18n_zip_path}/idp-i18n-bundle.zip ${work_dir}/idp-i18n-bundle/*
 zip -r -j ${i18n_zip_path}/mock-relying-party-i18n-bundle.zip ${work_dir}/mock-relying-party-i18n-bundle/*
 zip -r -j ${i18n_zip_path}/esignet-i18n-bundle.zip ${work_dir}/esignet-i18n-bundle/*
-zip -r -j ${i18n_zip_path}/resident-i18n-bundle.zip ${work_dir}/resident-i18n-bundle/*
 zip -r -j ${i18n_zip_path}/esignet-signup-i18n-bundle.zip ${work_dir}/esignet-signup-i18n-bundle/*
 rm -rf ${work_dir}/admin-i18n-bundle \
  ${work_dir}/pmp-i18n-bundle \
  ${work_dir}/pre-registration-i18n-bundle \
  ${work_dir}/oidc-demo-i18n-bundle \
- ${work_dir}/idp-i18n-bundle \
  ${work_dir}/mock-relying-party-i18n-bundle \
  ${work_dir}/esignet-i18n-bundle \
  ${work_dir}/resident-i18n-bundle \

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -34,7 +34,16 @@
 		</developer>
 	</developers>
 
-    <repositories>
+     <repositories>
+        <repository>
+            <id>ossrh</id>
+            <name>CentralRepository</name>
+            <url>https://central.sonatype.com/repositories/snapshots</url>
+            <layout>default</layout>
+            <snapshots>
+            <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>central</id>
             <name>MavenCentral</name>
@@ -44,25 +53,16 @@
             <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>ossrh</id>
-            <name>MavenSnapshot</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <layout>default</layout>
-            <snapshots>
-            <enabled>true</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 	
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
 		<repository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<url>https://central.sonatype.com/api/v1/publisher</url>
 		</repository>
 	</distributionManagement>
 
@@ -71,10 +71,6 @@
 		<auth-adapter.version>1.2.1-SNAPSHOT</auth-adapter.version>
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
-
-		<auth-adapter-java-21.version>1.2.1-java21-SNAPSHOT</auth-adapter-java-21.version>
-		<auth-adapter-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel/java21</auth-adapter-java-21.location>
-		<auth-adapter-java-21.fileName>kernel-auth-adapter.jar</auth-adapter-java-21.fileName>
 
 		<auth-adapter-lite.version>1.2.0.1-B4</auth-adapter-lite.version>
 		<auth-adapter-lite.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter-lite.location>
@@ -85,47 +81,21 @@
                 <kernel-transliteration.location>/usr/share/nginx/html/artifactory/libs-release-local/icu4j</kernel-transliteration.location>
                 <kernel-transliteration.fileName>kernel-transliteration-icu4j.jar</kernel-transliteration.fileName>
 
-                <!-- kernel-transliteration-jar java21-->
-                <kernel-transliteration-java-21.version>1.2.1-SNAPSHOT</kernel-transliteration-java-21.version>
-                <kernel-transliteration-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/icu4j/java21</kernel-transliteration-java-21.location>
-                <kernel-transliteration-java-21.fileName>kernel-transliteration-icu4j.jar</kernel-transliteration-java-21.fileName>
-
-
 		<!-- kernel-smsserviceprovider-->
 		<kernel-smsserviceprovider.version>1.2.1-SNAPSHOT</kernel-smsserviceprovider.version>
 		<kernel-smsserviceprovider.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</kernel-smsserviceprovider.location>
 		<kernel-smsserviceprovider.fileName>kernel-smsserviceprovider-msg91.jar</kernel-smsserviceprovider.fileName>
 
-		<!-- kernel-smsserviceprovider java21-->
-		<kernel-smsserviceprovider-java-21.version>1.2.1-java21-SNAPSHOT</kernel-smsserviceprovider-java-21.version>
-		<kernel-smsserviceprovider-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</kernel-smsserviceprovider-java-21.location>
-		<kernel-smsserviceprovider-java-21.fileName>kernel-smsserviceprovider-msg91.jar</kernel-smsserviceprovider-java-21.fileName>	
-
-		<!-- kernel-smsserviceprovider-msg91 java21-->
-		<kernel-smsserviceprovider-java-21.version>1.2.1-java21-SNAPSHOT</kernel-smsserviceprovider-java-21.version>
-		<kernel-smsserviceprovider-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel/java21</kernel-smsserviceprovider-java-21.location>
-		<kernel-smsserviceprovider-java-21.fileName>kernel-smsserviceprovider-msg91.jar</kernel-smsserviceprovider-java-21.fileName>
-		
 		<!-- kernel-ref-idobjectvalidator -->
 		<kernel-ref-idobjectvalidator.version>1.2.1-SNAPSHOT</kernel-ref-idobjectvalidator.version>
 		<kernel-ref-idobjectvalidator.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel/kernel-ref-idobjectvalidator</kernel-ref-idobjectvalidator.location>
 		<kernel-ref-idobjectvalidator.fileName>kernel-ref-idobjectvalidator.jar</kernel-ref-idobjectvalidator.fileName>
 
-		<!-- kernel-ref-idobjectvalidator java21 -->
-		<kernel-ref-idobjectvalidator-java-21.version>1.2.1-java21-SNAPSHOT</kernel-ref-idobjectvalidator-java-21.version>
-		<kernel-ref-idobjectvalidator-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel/kernel-ref-idobjectvalidator/java21</kernel-ref-idobjectvalidator-java-21.location>
-		<kernel-ref-idobjectvalidator-java-21.fileName>kernel-ref-idobjectvalidator.jar</kernel-ref-idobjectvalidator-java-21.fileName>
-		
 		<!-- kernel-virusscanner-clamav -->
 		<kernel-virusscanner-clamav.version>1.2.1-SNAPSHOT</kernel-virusscanner-clamav.version>
 		<kernel-virusscanner-clamav.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav</kernel-virusscanner-clamav.location>
 		<kernel-virusscanner-clamav.fileName>kernel-virusscanner-clamav.jar</kernel-virusscanner-clamav.fileName>
 
-		<!-- kernel-virusscanner-clamav java21 -->
-		<kernel-virusscanner-clamav-java-21.version>1.2.1-java21-SNAPSHOT</kernel-virusscanner-clamav-java-21.version>
-		<kernel-virusscanner-clamav-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav/java21</kernel-virusscanner-clamav-java-21.location>
-		<kernel-virusscanner-clamav-java-21.fileName>kernel-virusscanner-clamav.jar</kernel-virusscanner-clamav-java-21.fileName>
-		
 		<!-- registration-api-impl -->
 		<registration-api-impl.version>1.2.1-SNAPSHOT</registration-api-impl.version>
 		<registration-api-impl.location>/usr/share/nginx/html/artifactory/libs-release-local/registration-client/registration-api-impl</registration-api-impl.location>
@@ -142,12 +112,6 @@
 		<biosdk-client-lib.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/biosdk-lib</biosdk-client-lib.location>
 		<biosdk-client.fileName>biosdk-client-jar-with-dependencies.jar</biosdk-client.fileName>
 
-                <!-- biosdk-client JAVA-21-->
-		<biosdk-client-java21.version>1.2.1-java21-SNAPSHOT</biosdk-client-java21.version>
-		<biosdk-client-java21.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/mock/0.9/java21/biosdk-client</biosdk-client-java21.location>
-		<biosdk-client-lib-java21.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/java21/biosdk-lib</biosdk-client-lib-java21.location>
-		<biosdk-client-java21.fileName>biosdk-client-jar-with-dependencies.jar</biosdk-client-java21.fileName>
-		
 		<!-- demosdk-client -->
 		<demosdk-client.version>1.2.1-SNAPSHOT</demosdk-client.version>
 		<demosdk-client.location>/usr/share/nginx/html/artifactory/libs-release-local/demosdk/default/demosdk</demosdk-client.location>
@@ -159,12 +123,6 @@
 		<mock-sdk.fileName>mock-sdk.jar</mock-sdk.fileName>
 		<mock-sdk-dep.fileName>mock-sdk-jar-with-dependencies.jar</mock-sdk-dep.fileName>
 
-		<!-- mock-sdk -->
-		<mock-sdk-java21.version>1.2.1-java21-SNAPSHOT</mock-sdk-java21.version>
-		<mock-sdk-java21.location>/usr/share/nginx/html/artifactory/libs-release-local/mock-sdk/java21/</mock-sdk-java21.location>
-		<mock-sdk-java21.fileName>mock-sdk.jar</mock-sdk-java21.fileName>
-		<mock-sdk-dep-java21.fileName>mock-sdk-jar-with-dependencies.jar</mock-sdk-dep-java21.fileName>
-		
 		<!-- mock-sdk-jpeg-extractor -->
 		<mock-sdk-jpeg-extractor.version>1.2.1-SNAPSHOT</mock-sdk-jpeg-extractor.version>
 		<mock-sdk-jpeg-extractor.location>/usr/share/nginx/html/artifactory/libs-release-local/jpeg-mock-sdk/1.1.5</mock-sdk-jpeg-extractor.location>
@@ -185,11 +143,6 @@
 		<hazelcast.version>3.12.12</hazelcast.version>
 		<hazelcast.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</hazelcast.location>
 		<hazelcast.fileName>cache-provider.jar</hazelcast.fileName>
-
-		<!-- hazelcast cast java21 -->
-		<hazelcast-java-21.version>3.12.12</hazelcast-java-21.version>
-		<hazelcast-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/cache/java21</hazelcast-java-21.location>
-		<hazelcast-java-21.fileName>cache-provider.jar</hazelcast-java-21.fileName>
 		
 		<!-- idp authentication wrapper -->
 		<authentication-wrapper.version>0.9.0</authentication-wrapper.version>
@@ -283,25 +236,7 @@
 					<outputDirectory>${auth-adapter-lite.location}</outputDirectory> 
 					<destFileName>${auth-adapter-lite.fileName}</destFileName>
 					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for smsserviceprovider java21 -->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-smsserviceprovider-msg91</artifactId>
-					<version>${kernel-smsserviceprovider-java-21.version}</version>
-					 <outputDirectory>${kernel-smsserviceprovider-java-21.location}</outputDirectory> 
-					<destFileName>${kernel-smsserviceprovider-java-21.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for ref-idobjectvaidator java21 -->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-ref-idobjectvalidator</artifactId>
-					<version>${kernel-ref-idobjectvalidator-java-21.version}</version>
-					 <outputDirectory>${kernel-ref-idobjectvalidator-java-21.location}</outputDirectory> 
-					<destFileName>${kernel-ref-idobjectvalidator-java-21.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>					
+				</artifactItem>				
 					
 <!-- artifactItem section for smsserviceprovider -->
 				<artifactItem>
@@ -320,16 +255,6 @@
                                         <version>${kernel-transliteration.version}</version>
                                          <outputDirectory>${kernel-transliteration.location}</outputDirectory>
                                         <destFileName>${kernel-transliteration.fileName}</destFileName>
-                                        <type>jar</type>
-                                </artifactItem>
-
-<!-- artifactItem section for kernel-transliteration-icu4j java21 -->
-                                <artifactItem>
-                                        <groupId>io.mosip.kernel</groupId>
-                                        <artifactId>kernel-transliteration-icu4j</artifactId>
-                                        <version>${kernel-transliteration-java-21.version}</version>
-                                         <outputDirectory>${kernel-transliteration-java-21.location}</outputDirectory>
-                                        <destFileName>${kernel-transliteration-java-21.fileName}</destFileName>
                                         <type>jar</type>
                                 </artifactItem>
 
@@ -369,16 +294,7 @@
 					 <outputDirectory>${kernel-virusscanner-clamav-java-21.location}</outputDirectory> 
 					<destFileName>${kernel-virusscanner-clamav.fileName}</destFileName>
 					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for virusscanner java21-->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-virusscanner-clamav</artifactId>
-					<version>${kernel-virusscanner-clamav.version}</version>
-					 <outputDirectory>${kernel-virusscanner-clamav.location}</outputDirectory> 
-					<destFileName>${kernel-virusscanner-clamav-java-21.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>					
+				</artifactItem>				
 <!-- artifactItem section for clamav client -->
 				<artifactItem>
 					<groupId>xyz.capybara</groupId>
@@ -404,25 +320,6 @@
 					<version>${biosdk-client.version}</version>
 					 <outputDirectory>${biosdk-client.location}</outputDirectory> 
 					<destFileName>${biosdk-client.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for mock-sdk -->
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk</artifactId>
-					<version>${mock-sdk-java21.version}</version>
-					 <outputDirectory>${mock-sdk-java21.location}</outputDirectory> 
-					<destFileName>${mock-sdk-java21.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for biosdk-client -->				
-				<artifactItem>
-					<groupId>io.mosip.biosdk</groupId>
-					<artifactId>biosdk-client</artifactId>
-					<version>${biosdk-client-java21.version}</version>
-					 <outputDirectory>${biosdk-client-java21.location}</outputDirectory> 
-					<destFileName>${biosdk-client-java21.fileName}</destFileName>
 					<classifier>jar-with-dependencies</classifier>
 					<type>jar</type>
 				</artifactItem>
@@ -493,15 +390,6 @@
 					<classifier>jar-with-dependencies</classifier>
 					<type>jar</type>
 				</artifactItem>
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk</artifactId>
-					<version>${mock-sdk-java21.version}</version>
-					 <outputDirectory>${biosdk-client-lib-java21.location}</outputDirectory> 
-					<destFileName>${mock-sdk-dep.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-				</artifactItem>
 <!-- artifactItem section for hazelcast-all jar -->
 				<artifactItem>
 					<groupId>com.hazelcast</groupId>
@@ -510,16 +398,7 @@
 					 <outputDirectory>${hazelcast.location}</outputDirectory> 
 					<destFileName>${hazelcast.fileName}</destFileName>
 					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for hazelcast java21 jar -->
-				<artifactItem>
-					<groupId>com.hazelcast</groupId>
-					<artifactId>hazelcast-all</artifactId>
-					<version>${hazelcast-java-21.version}</version>
-					 <outputDirectory>${hazelcast-java-21.location}</outputDirectory> 
-					<destFileName>${hazelcast-java-21.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>					
+				</artifactItem>				
 <!-- artifactItem section for redis-cache jar -->
 				<artifactItem>
 					<groupId>io.mosip.cacheprovider</groupId>

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -68,7 +68,7 @@
 
 	<properties>
 		<!-- kernel-auth-apadter -->
-		<auth-adapter.version>1.3.0-SNAPSHOT</auth-adapter.version>
+		<auth-adapter.version>1.3.0</auth-adapter.version>
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
 

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -68,7 +68,7 @@
 
 	<properties>
 		<!-- kernel-auth-apadter -->
-		<auth-adapter.version>1.2.1-SNAPSHOT</auth-adapter.version>
+		<auth-adapter.version>1.3.0-SNAPSHOT</auth-adapter.version>
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
 

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -68,7 +68,7 @@
 
 	<properties>
 		<!-- kernel-auth-apadter -->
-		<auth-adapter.version>1.3.0</auth-adapter.version>
+		<auth-adapter.version>1.2.1-SNAPSHOT</auth-adapter.version>
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
 

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -34,27 +34,28 @@
 		</developer>
 	</developers>
 
-     <repositories>
-        <repository>
-            <id>ossrh</id>
-            <name>CentralRepository</name>
-            <url>https://central.sonatype.com/repositories/snapshots</url>
-            <layout>default</layout>
-            <snapshots>
-            <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>central</id>
-            <name>MavenCentral</name>
-            <layout>default</layout>
-            <url>https://repo1.maven.org/maven2</url>
-            <snapshots>
-            <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-	
+	<!-- Repo URL verified against released branch (working) - no change needed -->
+	<repositories>
+		<repository>
+			<id>central</id>
+			<name>MavenCentral</name>
+			<layout>default</layout>
+			<url>https://repo1.maven.org/maven2</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>ossrh</id>
+			<name>CentralRepository</name>
+			<url>https://central.sonatype.com/repository/maven-snapshots</url>
+			<layout>default</layout>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
@@ -72,6 +73,15 @@
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
 
+		<!--
+			FIX 1: auth-adapter-java-21 properties were referenced in an artifactItem
+			but never declared in <properties>, causing Maven to pass the literal
+			string '${auth-adapter-java-21.version}' as the version → resolution fails.
+		-->
+		<auth-adapter-java-21.version>1.2.1-SNAPSHOT</auth-adapter-java-21.version>
+		<auth-adapter-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/mock/0.9/java21</auth-adapter-java-21.location>
+
+		<!-- auth-adapter-lite (kept for backward compatibility) -->
 		<auth-adapter-lite.version>1.2.0.1-B4</auth-adapter-lite.version>
 		<auth-adapter-lite.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter-lite.location>
 		<auth-adapter-lite.fileName>kernel-auth-adapter-lite.jar</auth-adapter-lite.fileName>
@@ -95,6 +105,13 @@
 		<kernel-virusscanner-clamav.version>1.2.1-SNAPSHOT</kernel-virusscanner-clamav.version>
 		<kernel-virusscanner-clamav.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav</kernel-virusscanner-clamav.location>
 		<kernel-virusscanner-clamav.fileName>kernel-virusscanner-clamav.jar</kernel-virusscanner-clamav.fileName>
+
+		<!--
+			FIX 2: Same as FIX 1 — kernel-virusscanner-clamav-java-21 properties
+			were used in an artifactItem but never declared here.
+		-->
+		<kernel-virusscanner-clamav-java-21.version>1.2.1-SNAPSHOT</kernel-virusscanner-clamav-java-21.version>
+		<kernel-virusscanner-clamav-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav/java21</kernel-virusscanner-clamav-java-21.location>
 
 		<!-- registration-api-impl -->
 		<registration-api-impl.version>1.2.1-SNAPSHOT</registration-api-impl.version>
@@ -154,41 +171,25 @@
 		<esignet-mock-wrapper.version>0.9.2</esignet-mock-wrapper.version>
 		<esignet-mock-wrapper.fileName>esignet-mock-wrapper.jar</esignet-mock-wrapper.fileName>
 
- 		<!-- certify sunbird plugin -->
-		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
-<!--		<certify-sunbird-plugin.version>0.3.0-SNAPSHOT</certify-sunbird-plugin.version>-->
-<!--		<certify-sunbird-plugin.fileName>certify-sunbird-plugin.jar</certify-sunbird-plugin.fileName>-->
-		<!-- certify mosip identity plugin -->
-		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
-		<certify-mosip-identity-plugin.version>0.3.0-SNAPSHOT</certify-mosip-identity-plugin.version>
-		<certify-mosip-identity-plugin.fileName>certify-mosip-identity-plugin.jar</certify-mosip-identity-plugin.fileName>
-
-        <!-- certify mock plugin -->
-		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
-		<certify-mock-plugin.version>0.3.1-SNAPSHOT</certify-mock-plugin.version>
-		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
-
-		<!-- certify mock ida dataprovider plugin -->
-		<certify-mock-ida-dataprovider-plugin.version>0.3.0-SNAPSHOT</certify-mock-ida-dataprovider-plugin.version>
-        <certify-mock-ida-dataprovider-plugin.fileName>certify-mock-ida-dataprovider-plugin.jar</certify-mock-ida-dataprovider-plugin.fileName>
-
-		<!-- certify postgres plugin -->
-<!--		<certify-postgres-dataprovider-plugin.version>0.3.0-SNAPSHOT</certify-postgres-dataprovider-plugin.version>-->
-<!--		<certify-postgres-dataprovider-plugin.fileName>certify-postgres-dataprovider-plugin.jar</certify-postgres-dataprovider-plugin.fileName>-->
-
-
 		<!-- esignet IDA wrapper -->
 		<esignet-ida-wrapper.version>1.2.1-SNAPSHOT</esignet-ida-wrapper.version>
 		<esignet-ida-wrapper.fileName>esignet-ida-wrapper.jar</esignet-ida-wrapper.fileName>
-<!-- 		<esignet-digital-credential-wrapper.version>0.3.0-SNAPSHOT</esignet-digital-credential-wrapper.version>
-		<esignet-digital-credential-wrapper.fileName>sunbird-rc-esignet-integration-impl.jar</esignet-digital-credential-wrapper.fileName> -->
-		
+
+		<!-- esignet plugins -->
 		<esignet-plugins.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-plugins</esignet-plugins.location>
 		<esignet-mock-plugin.version>1.3.0-SNAPSHOT</esignet-mock-plugin.version>
 		<esignet-mock-plugin.fileName>esignet-mock-plugin.jar</esignet-mock-plugin.fileName>
 		<mosip-identity-plugin.version>1.3.0-SNAPSHOT</mosip-identity-plugin.version>
 		<mosip-identity-plugin.fileName>mosip-identity-plugin.jar</mosip-identity-plugin.fileName>
-		
+
+		<!-- certify plugins -->
+		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
+		<certify-mosip-identity-plugin.version>0.3.0-SNAPSHOT</certify-mosip-identity-plugin.version>
+		<certify-mosip-identity-plugin.fileName>certify-mosip-identity-plugin.jar</certify-mosip-identity-plugin.fileName>
+		<certify-mock-plugin.version>0.3.1-SNAPSHOT</certify-mock-plugin.version>
+		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
+		<certify-mock-ida-dataprovider-plugin.version>0.3.0-SNAPSHOT</certify-mock-ida-dataprovider-plugin.version>
+		<certify-mock-ida-dataprovider-plugin.fileName>certify-mock-ida-dataprovider-plugin.jar</certify-mock-ida-dataprovider-plugin.fileName>
 	</properties>
 	
 	<build>
@@ -257,16 +258,6 @@
                                         <destFileName>${kernel-transliteration.fileName}</destFileName>
                                         <type>jar</type>
                                 </artifactItem>
-
-<!-- artifactItem section for smsserviceprovider -->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-smsserviceprovider-msg91</artifactId>
-					<version>${kernel-smsserviceprovider.version}</version>
-					 <outputDirectory>${kernel-smsserviceprovider.location}</outputDirectory> 
-					<destFileName>${kernel-smsserviceprovider.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
 					
 <!-- artifactItem section for ref-idobjectvaidator -->
 				<artifactItem>

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -122,7 +122,7 @@
 		<image-compressor.fileName>image-compressor-jar-with-dependencies.jar</image-compressor.fileName>
 
 		<!-- redis-cache -->
-		<redis-cache.version>1.3.1-SNAPSHOT</redis-cache.version>
+		<redis-cache.version>1.2.1-SNAPSHOT</redis-cache.version>
 		<redis-cache.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</redis-cache.location>
 		<redis-cache.fileName>redis-cache-provider.jar</redis-cache.fileName>
 

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -200,16 +200,6 @@
 					<type>jar</type>
 				</artifactItem>
 
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-auth-adapter</artifactId>
-					<version>${auth-adapter-java-21.version}</version>
-					<outputDirectory>${auth-adapter-java-21.location}</outputDirectory>
-						<!-- Keep the destination filename consistent with the original -->
-					<destFileName>kernel-auth-adapter.jar</destFileName>
-					<type>jar</type>
-				</artifactItem>
-
 
 				<artifactItem>
 	       	 	                <groupId>io.mosip.kernel</groupId>
@@ -258,15 +248,6 @@
 					<destFileName>${registration-api-impl.fileName}</destFileName>
 					<type>jar</type>
 				</artifactItem>
-<!-- artifactItem section for virusscanner -->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-virusscanner-clamav</artifactId>
-					<version>${kernel-virusscanner-clamav-java-21.version}</version>
-					 <outputDirectory>${kernel-virusscanner-clamav-java-21.location}</outputDirectory> 
-					<destFileName>${kernel-virusscanner-clamav.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>				
 <!-- artifactItem section for clamav client -->
 				<artifactItem>
 					<groupId>xyz.capybara</groupId>

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -135,16 +135,10 @@
 		<demosdk-client.fileName>demosdk-client-jar-with-dependencies.jar</demosdk-client.fileName>
 		
 		<!-- mock-sdk -->
-		<mock-sdk.version>1.2.1-SNAPSHOT</mock-sdk.version>
+		<mock-sdk.version>1.3.0-SNAPSHOT</mock-sdk.version>
 		<mock-sdk.location>/usr/share/nginx/html/artifactory/libs-release-local/mock-sdk/1.1.5</mock-sdk.location>
 		<mock-sdk.fileName>mock-sdk.jar</mock-sdk.fileName>
 		<mock-sdk-dep.fileName>mock-sdk-jar-with-dependencies.jar</mock-sdk-dep.fileName>
-
-		<!-- mock-sdk-jpeg-extractor -->
-		<mock-sdk-jpeg-extractor.version>1.2.1-SNAPSHOT</mock-sdk-jpeg-extractor.version>
-		<mock-sdk-jpeg-extractor.location>/usr/share/nginx/html/artifactory/libs-release-local/jpeg-mock-sdk/1.1.5</mock-sdk-jpeg-extractor.location>
-		<mock-sdk-jpeg-extractor-lib.location>/usr/share/nginx/html/artifactory/libs-release-local/jpeg-sdk/jpeg-sdk-lib</mock-sdk-jpeg-extractor-lib.location>
-		<mock-sdk-jpeg-extractor.fileName>mock-sdk-jpeg-extractor-jar-with-dependencies.jar</mock-sdk-jpeg-extractor.fileName>
 		
 		<!-- image-compressor-->
 		<image-compressor.version>0.0.1-SNAPSHOT</image-compressor.version>
@@ -152,7 +146,7 @@
 		<image-compressor.fileName>image-compressor-jar-with-dependencies.jar</image-compressor.fileName>
 		
 		<!-- redis-cache -->
-		<redis-cache.version>1.0-SNAPSHOT</redis-cache.version>
+		<redis-cache.version>1.3.0-SNAPSHOT</redis-cache.version>
 		<redis-cache.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</redis-cache.location>
 		<redis-cache.fileName>redis-cache-provider.jar</redis-cache.fileName>
 		
@@ -172,24 +166,24 @@
 		<esignet-mock-wrapper.fileName>esignet-mock-wrapper.jar</esignet-mock-wrapper.fileName>
 
 		<!-- esignet IDA wrapper -->
-		<esignet-ida-wrapper.version>1.2.1-SNAPSHOT</esignet-ida-wrapper.version>
+		<esignet-ida-wrapper.version>1.2.0.1</esignet-ida-wrapper.version>
 		<esignet-ida-wrapper.fileName>esignet-ida-wrapper.jar</esignet-ida-wrapper.fileName>
 
 		<!-- esignet plugins -->
 		<esignet-plugins.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-plugins</esignet-plugins.location>
-		<esignet-mock-plugin.version>1.3.0-SNAPSHOT</esignet-mock-plugin.version>
+		<esignet-mock-plugin.version>1.4.0-SNAPSHOT</esignet-mock-plugin.version>
 		<esignet-mock-plugin.fileName>esignet-mock-plugin.jar</esignet-mock-plugin.fileName>
-		<mosip-identity-plugin.version>1.3.0-SNAPSHOT</mosip-identity-plugin.version>
+		<mosip-identity-plugin.version>1.4.0-SNAPSHOT</mosip-identity-plugin.version>
 		<mosip-identity-plugin.fileName>mosip-identity-plugin.jar</mosip-identity-plugin.fileName>
 
 		<!-- certify plugins -->
 		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
-		<certify-mosip-identity-plugin.version>0.3.0-SNAPSHOT</certify-mosip-identity-plugin.version>
+		<certify-mosip-identity-plugin.version>0.3.0</certify-mosip-identity-plugin.version>
 		<certify-mosip-identity-plugin.fileName>certify-mosip-identity-plugin.jar</certify-mosip-identity-plugin.fileName>
-		<certify-mock-plugin.version>0.3.1-SNAPSHOT</certify-mock-plugin.version>
+		<certify-mock-plugin.version>0.3.0</certify-mock-plugin.version>
 		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
-		<certify-mock-ida-dataprovider-plugin.version>0.3.0-SNAPSHOT</certify-mock-ida-dataprovider-plugin.version>
-		<certify-mock-ida-dataprovider-plugin.fileName>certify-mock-ida-dataprovider-plugin.jar</certify-mock-ida-dataprovider-plugin.fileName>
+		<certify-sunbird-plugin.version>0.3.0</certify-sunbird-plugin.version>
+		<certify-sunbird-plugin.fileName>certify-sunbird-plugin.jar</certify-sunbird-plugin.fileName>
 	</properties>
 	
 	<build>
@@ -333,35 +327,7 @@
 					<destFileName>${image-compressor.fileName}</destFileName>
 					<classifier>jar-with-dependencies</classifier>
 					<type>jar</type>
-                </artifactItem>							
-<!-- artifactItem section for mock-sdk-jpeg-extractor -->
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk-jpeg-extractor</artifactId>
-					<version>${mock-sdk-jpeg-extractor.version}</version>
-					 <outputDirectory>${mock-sdk-jpeg-extractor.location}</outputDirectory> 
-					<destFileName>${mock-sdk-jpeg-extractor.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for mock-sdk-jpeg-extractor lib-->
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk</artifactId>
-					<version>${mock-sdk.version}</version>
-					 <outputDirectory>${mock-sdk-jpeg-extractor-lib.location}</outputDirectory> 
-					<destFileName>${mock-sdk.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>	
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk-jpeg-extractor</artifactId>
-					<version>${mock-sdk-jpeg-extractor.version}</version>
-					 <outputDirectory>${mock-sdk-jpeg-extractor-lib.location}</outputDirectory> 
-					<destFileName>${mock-sdk-jpeg-extractor.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-				</artifactItem>
+                </artifactItem>
 <!-- artifactItem section for biosdk library -->
 <!-- Commented as per discussion. as jar with dependencies will have components of jar as well.
 				<artifactItem>
@@ -469,13 +435,13 @@
 <!--						<destFileName>${certify-postgres-dataprovider-plugin.fileName}</destFileName>-->
 <!--						<type>jar</type>-->
 <!--					</artifactItem>-->
-<!-- artifactItem section for certify mock ida dataprovider plugin -->
+					<!-- artifactItem section for certify sunbird plugin -->
 					<artifactItem>
-						<groupId>io.mosip.certify</groupId>
-						<artifactId>mock-ida-dataprovider-plugin</artifactId>
-						<version>${certify-mock-ida-dataprovider-plugin.version}</version>
+						<groupId>io.mosip.certify.sunbirdrc</groupId>
+						<artifactId>sunbird-rc-certify-integration-impl</artifactId>
+						<version>${certify-sunbird-plugin.version}</version>
 						<outputDirectory>${certify-plugin.location}</outputDirectory>
-						<destFileName>${certify-mock-ida-dataprovider-plugin.fileName}</destFileName>
+						<destFileName>${certify-sunbird-plugin.fileName}</destFileName>
 						<type>jar</type>
 					</artifactItem>
 

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -171,9 +171,9 @@
 
 		<!-- esignet plugins -->
 		<esignet-plugins.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-plugins</esignet-plugins.location>
-		<esignet-mock-plugin.version>1.3.4</esignet-mock-plugin.version>
+		<esignet-mock-plugin.version>1.4.0-SNAPSHOT</esignet-mock-plugin.version>
 		<esignet-mock-plugin.fileName>esignet-mock-plugin.jar</esignet-mock-plugin.fileName>
-		<mosip-identity-plugin.version>1.3.4</mosip-identity-plugin.version>
+		<mosip-identity-plugin.version>1.4.0-SNAPSHOT</mosip-identity-plugin.version>
 		<mosip-identity-plugin.fileName>mosip-identity-plugin.jar</mosip-identity-plugin.fileName>
 
 		<!-- certify plugins -->
@@ -446,7 +446,7 @@
 					</artifactItem>
 
 					<artifactItem>
-						<groupId>io.mosip.esignet.plugin</groupId>
+						<groupId>io.mosip.esignet</groupId>
 						<version>${mosip-identity-plugin.version}</version>
 						<artifactId>mosip-identity-plugin</artifactId>
 						<outputDirectory>${esignet-plugins.location}</outputDirectory>
@@ -455,7 +455,7 @@
 					</artifactItem>
 
 					<artifactItem>
-						<groupId>io.mosip.esignet.plugin</groupId>
+						<groupId>io.mosip.esignet</groupId>
 						<version>${esignet-mock-plugin.version}</version>
 						<artifactId>mock-plugin</artifactId>
 						<outputDirectory>${esignet-plugins.location}</outputDirectory>

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -47,7 +47,7 @@
 		</repository>
 		<repository>
 			<id>ossrh</id>
-			<name>CentralRepository</name>
+			<name>MavenCentralRepository</name>
 			<url>https://central.sonatype.com/repository/maven-snapshots</url>
 			<layout>default</layout>
 			<snapshots>
@@ -140,11 +140,6 @@
 		<hazelcast.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</hazelcast.location>
 		<hazelcast.fileName>cache-provider.jar</hazelcast.fileName>
 		
-		<!-- idp authentication wrapper -->
-		<authentication-wrapper.version>0.9.0</authentication-wrapper.version>
-		<authentication-wrapper.location>/usr/share/nginx/html/artifactory/libs-release-local/idp/idp-auth-wrapper</authentication-wrapper.location>
-		<authentication-wrapper.fileName>authentication-wrapper.jar</authentication-wrapper.fileName>
-		
 		<!-- esignet mock authentication wrapper -->
 		<esignet-wrapper.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-wrapper</esignet-wrapper.location>
 		<esignet-mock-wrapper.version>0.9.2</esignet-mock-wrapper.version>
@@ -154,289 +149,240 @@
 		<esignet-ida-wrapper.version>1.2.0.1</esignet-ida-wrapper.version>
 		<esignet-ida-wrapper.fileName>esignet-ida-wrapper.jar</esignet-ida-wrapper.fileName>
 
-		<!-- esignet plugins -->
-		<esignet-plugins.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-plugins</esignet-plugins.location>
-		<esignet-mock-plugin.version>1.4.0-SNAPSHOT</esignet-mock-plugin.version>
-		<esignet-mock-plugin.fileName>esignet-mock-plugin.jar</esignet-mock-plugin.fileName>
-		<mosip-identity-plugin.version>1.4.0-SNAPSHOT</mosip-identity-plugin.version>
-		<mosip-identity-plugin.fileName>mosip-identity-plugin.jar</mosip-identity-plugin.fileName>
+		<!-- esignet sunbird wrapper -->
+		<esignet-digital-credential-wrapper.version>0.2.1</esignet-digital-credential-wrapper.version>
+		<esignet-digital-credential-wrapper.fileName>sunbird-rc-esignet-integration-impl.jar</esignet-digital-credential-wrapper.fileName>
 
-		<!-- certify mosip identity plugin -->
 		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
+		<!-- certify sunbird plugin  -->
+		<certify-sunbird-plugin.version>0.3.0</certify-sunbird-plugin.version>
+		<certify-sunbird-plugin.fileName>certify-sunbird-plugin.jar</certify-sunbird-plugin.fileName>
+		<!-- certify mosip identity plugin -->
 		<certify-mosip-identity-plugin.version>0.3.0</certify-mosip-identity-plugin.version>
 		<certify-mosip-identity-plugin.fileName>certify-mosip-identity-plugin.jar</certify-mosip-identity-plugin.fileName>
-
 		<!-- certify mock plugin -->
 		<certify-mock-plugin.version>0.3.0</certify-mock-plugin.version>
 		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
-		<certify-sunbird-plugin.version>0.3.0</certify-sunbird-plugin.version>
-		<certify-sunbird-plugin.fileName>certify-sunbird-plugin.jar</certify-sunbird-plugin.fileName>
 	</properties>
-	
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-        			<version>3.5.0</version>
-        <executions>
-          <execution>
-            <id>copy</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-	  </execution>
-	</executions>
-			<configuration>
-				<artifactItems>
-<!-- artifactItem section for auth adapter -->
-				<artifactItem>
-	       	 	    <groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-auth-adapter</artifactId>
-					<version>${auth-adapter.version}</version>
-					 <outputDirectory>${auth-adapter.location}</outputDirectory> 
-					<destFileName>${auth-adapter.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<!-- artifactItem section for auth adapter -->
+						<artifactItem>
+							<groupId>io.mosip.kernel</groupId>
+							<artifactId>kernel-auth-adapter</artifactId>
+							<version>${auth-adapter.version}</version>
+							<outputDirectory>${auth-adapter.location}</outputDirectory>
+							<destFileName>${auth-adapter.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
 
+						<artifactItem>
+							<groupId>io.mosip.kernel</groupId>
+							<artifactId>kernel-auth-adapter-lite</artifactId>
+							<version>${auth-adapter-lite.version}</version>
+							<outputDirectory>${auth-adapter-lite.location}</outputDirectory>
+							<destFileName>${auth-adapter-lite.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
 
-				<artifactItem>
-	       	 	                <groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-auth-adapter-lite</artifactId>
-					<version>${auth-adapter-lite.version}</version>
-					<outputDirectory>${auth-adapter-lite.location}</outputDirectory> 
-					<destFileName>${auth-adapter-lite.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>				
-					
-<!-- artifactItem section for smsserviceprovider -->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-smsserviceprovider-msg91</artifactId>
-					<version>${kernel-smsserviceprovider.version}</version>
-					 <outputDirectory>${kernel-smsserviceprovider.location}</outputDirectory> 
-					<destFileName>${kernel-smsserviceprovider.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
+						<!-- artifactItem section for smsserviceprovider -->
+						<artifactItem>
+							<groupId>io.mosip.kernel</groupId>
+							<artifactId>kernel-smsserviceprovider-msg91</artifactId>
+							<version>${kernel-smsserviceprovider.version}</version>
+							<outputDirectory>${kernel-smsserviceprovider.location}</outputDirectory>
+							<destFileName>${kernel-smsserviceprovider.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
 
-<!-- artifactItem section for kernel-transliteration-icu4j -->
-                                <artifactItem>
-                                        <groupId>io.mosip.kernel</groupId>
-                                        <artifactId>kernel-transliteration-icu4j</artifactId>
-                                        <version>${kernel-transliteration.version}</version>
-                                         <outputDirectory>${kernel-transliteration.location}</outputDirectory>
-                                        <destFileName>${kernel-transliteration.fileName}</destFileName>
-                                        <type>jar</type>
-                                </artifactItem>
-					
-<!-- artifactItem section for ref-idobjectvaidator -->
-				<artifactItem>
-					<groupId>io.mosip.kernel</groupId>
-					<artifactId>kernel-ref-idobjectvalidator</artifactId>
-					<version>${kernel-ref-idobjectvalidator.version}</version>
-					 <outputDirectory>${kernel-ref-idobjectvalidator.location}</outputDirectory> 
-					<destFileName>${kernel-ref-idobjectvalidator.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for registration-api-impl -->
-				<artifactItem>
-					<groupId>io.mosip.registration</groupId>
-					<artifactId>registration-api-stub-impl</artifactId>
-					<version>${registration-api-impl.version}</version>
-					 <outputDirectory>${registration-api-impl.location}</outputDirectory> 
-					<destFileName>${registration-api-impl.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for clamav client -->
-				<artifactItem>
-					<groupId>xyz.capybara</groupId>
-					<artifactId>clamav-client</artifactId>
-					<version>${clamav-client.version}</version>
-					 <outputDirectory>${clamav-client.location}</outputDirectory> 
-					<destFileName>${clamav-client.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for mock-sdk -->
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk</artifactId>
-					<version>${mock-sdk.version}</version>
-					 <outputDirectory>${mock-sdk.location}</outputDirectory> 
-					<destFileName>${mock-sdk.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for biosdk-client -->				
-				<artifactItem>
-					<groupId>io.mosip.biosdk</groupId>
-					<artifactId>biosdk-client</artifactId>
-					<version>${biosdk-client.version}</version>
-					 <outputDirectory>${biosdk-client.location}</outputDirectory> 
-					<destFileName>${biosdk-client.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for demosdk client -->
-               	<artifactItem>
-					<groupId>io.mosip.demosdk</groupId>
-					<artifactId>demosdk</artifactId>
-					<version>${demosdk-client.version}</version>
-					 <outputDirectory>${demosdk-client.location}</outputDirectory> 
-					<destFileName>${demosdk-client.fileName}</destFileName>
-			 		<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-                </artifactItem>
-<!-- artifactItem section for image-compressor dependency -->
-               	<artifactItem>
-					<groupId>io.mosip.image.compressor</groupId>
-					<artifactId>image-compressor</artifactId>
-					<version>${image-compressor.version}</version>
-					 <outputDirectory>${image-compressor.location}</outputDirectory> 
-					<destFileName>${image-compressor.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-                </artifactItem>
-<!-- artifactItem section for biosdk library -->
-<!-- Commented as per discussion. as jar with dependencies will have components of jar as well.
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk</artifactId>
-					<version>${mock-sdk.version}</version>
-					 <outputDirectory>${biosdk-client-lib.location}</outputDirectory> 
-					<destFileName>${mock-sdk.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>	-->
-				<artifactItem>
-					<groupId>io.mosip.mock.sdk</groupId>
-					<artifactId>mock-sdk</artifactId>
-					<version>${mock-sdk.version}</version>
-					 <outputDirectory>${biosdk-client-lib.location}</outputDirectory> 
-					<destFileName>${mock-sdk-dep.fileName}</destFileName>
-					<classifier>jar-with-dependencies</classifier>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for hazelcast-all jar -->
-				<artifactItem>
-					<groupId>com.hazelcast</groupId>
-					<artifactId>hazelcast-all</artifactId>
-					<version>${hazelcast.version}</version>
-					 <outputDirectory>${hazelcast.location}</outputDirectory> 
-					<destFileName>${hazelcast.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>				
-<!-- artifactItem section for redis-cache jar -->
-				<artifactItem>
-					<groupId>io.mosip.cacheprovider</groupId>
-					<artifactId>cache-provider-redis</artifactId>
-					<version>${redis-cache.version}</version>
-					 <outputDirectory>${redis-cache.location}</outputDirectory> 
-					<destFileName>${redis-cache.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for idp authentication wrapper - only required for idp v090-->
-				<artifactItem>
-					<groupId>io.mosip.idp</groupId>
-					<artifactId>authentication-wrapper</artifactId>
-					<version>${authentication-wrapper.version}</version>
-					 <outputDirectory>${authentication-wrapper.location}</outputDirectory> 
-					<destFileName>${authentication-wrapper.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-<!-- artifactItem section for esignet authentication wrapper -->
-				<artifactItem>
-					<groupId>io.mosip.esignet.mock</groupId>
-					<artifactId>mock-esignet-integration-impl</artifactId>
-					<version>${esignet-mock-wrapper.version}</version>
-					<outputDirectory>${esignet-wrapper.location}</outputDirectory>
-					<destFileName>${esignet-mock-wrapper.fileName}</destFileName>
-					<type>jar</type>
-				</artifactItem>
-					<artifactItem>
-						<groupId>io.mosip.authentication</groupId>
-						<artifactId>esignet-integration-impl</artifactId>
-						<version>${esignet-ida-wrapper.version}</version>
-						<outputDirectory>${esignet-wrapper.location}</outputDirectory>
-						<destFileName>${esignet-ida-wrapper.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem>
-<!-- 					<artifactItem>
-                                                <groupId>io.mosip.esignet.sunbirdrc</groupId>
-	                                        <artifactId>sunbird-rc-esignet-integration-impl</artifactId>
-						<version>${esignet-digital-credential-wrapper.version}</version>
-						<outputDirectory>${esignet-wrapper.location}</outputDirectory>
-						<destFileName>${esignet-digital-credential-wrapper.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem> -->
-<!-- artifactItem section for certify plugin -->				
-<!-- 					<artifactItem>
-                                                <groupId>io.mosip.certify.sunbirdrc</groupId>
-	                                        <artifactId>sunbird-rc-certify-integration-impl</artifactId>
-						<version>${certify-sunbird-plugin.version}</version>
-						<outputDirectory>${certify-plugin.location}</outputDirectory>
-						<destFileName>${certify-sunbird-plugin.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem> -->
-<!-- artifactItem section for certify mosip identity plugin -->
-<!--					<artifactItem>-->
-<!--						<groupId>io.mosip.certify</groupId>-->
-<!--						<artifactId>mosip-identity-certify-plugin</artifactId>-->
-<!--						<version>${certify-mosip-identity-plugin.version}</version>-->
-<!--						<outputDirectory>${certify-plugin.location}</outputDirectory>-->
-<!--						<destFileName>${certify-mosip-identity-plugin.fileName}</destFileName>-->
-<!--						<type>jar</type>-->
-<!--					</artifactItem>-->
-<!-- artifactItem section for certify mock identity plugin -->
-					<artifactItem>
-						<groupId>io.mosip.certify</groupId>
-						<artifactId>mock-certify-plugin</artifactId>
-						<version>${certify-mock-plugin.version}</version>
-						<outputDirectory>${certify-plugin.location}</outputDirectory>
-						<destFileName>${certify-mock-plugin.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem>
-<!-- artifactItem section for certify postgres dataprovider plugin -->
-<!--					<artifactItem>-->
-<!--						<groupId>io.mosip.certify</groupId>-->
-<!--						<artifactId>postgres-dataprovider-plugin</artifactId>-->
-<!--						<version>${certify-postgres-dataprovider-plugin.version}</version>-->
-<!--						<outputDirectory>${certify-plugin.location}</outputDirectory>-->
-<!--						<destFileName>${certify-postgres-dataprovider-plugin.fileName}</destFileName>-->
-<!--						<type>jar</type>-->
-<!--					</artifactItem>-->
-					<!-- artifactItem section for certify sunbird plugin -->
-					<artifactItem>
-						<groupId>io.mosip.certify.sunbirdrc</groupId>
-						<artifactId>sunbird-rc-certify-integration-impl</artifactId>
-						<version>${certify-sunbird-plugin.version}</version>
-						<outputDirectory>${certify-plugin.location}</outputDirectory>
-						<destFileName>${certify-sunbird-plugin.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem>
+						<!-- artifactItem section for kernel-transliteration-icu4j -->
+						<artifactItem>
+							<groupId>io.mosip.kernel</groupId>
+							<artifactId>kernel-transliteration-icu4j</artifactId>
+							<version>${kernel-transliteration.version}</version>
+							<outputDirectory>${kernel-transliteration.location}</outputDirectory>
+							<destFileName>${kernel-transliteration.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for ref-idobjectvaidator -->
+						<artifactItem>
+							<groupId>io.mosip.kernel</groupId>
+							<artifactId>kernel-ref-idobjectvalidator</artifactId>
+							<version>${kernel-ref-idobjectvalidator.version}</version>
+							<outputDirectory>${kernel-ref-idobjectvalidator.location}</outputDirectory>
+							<destFileName>${kernel-ref-idobjectvalidator.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
 
-					<artifactItem>
-						<groupId>io.mosip.esignet</groupId>
-						<version>${mosip-identity-plugin.version}</version>
-						<artifactId>mosip-identity-plugin</artifactId>
-						<outputDirectory>${esignet-plugins.location}</outputDirectory>
-						<destFileName>${mosip-identity-plugin.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem>
+						<!-- artifactItem section for registration-api-impl -->
+						<artifactItem>
+							<groupId>io.mosip.registration</groupId>
+							<artifactId>registration-api-stub-impl</artifactId>
+							<version>${registration-api-impl.version}</version>
+							<outputDirectory>${registration-api-impl.location}</outputDirectory>
+							<destFileName>${registration-api-impl.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for virusscanner -->
+						<artifactItem>
+							<groupId>io.mosip.kernel</groupId>
+							<artifactId>kernel-virusscanner-clamav</artifactId>
+							<version>${kernel-virusscanner-clamav.version}</version>
+							<outputDirectory>${kernel-virusscanner-clamav.location}</outputDirectory>
+							<destFileName>${kernel-virusscanner-clamav.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for clamav client -->
+						<artifactItem>
+							<groupId>xyz.capybara</groupId>
+							<artifactId>clamav-client</artifactId>
+							<version>${clamav-client.version}</version>
+							<outputDirectory>${clamav-client.location}</outputDirectory>
+							<destFileName>${clamav-client.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for mock-sdk -->
+						<artifactItem>
+							<groupId>io.mosip.mock.sdk</groupId>
+							<artifactId>mock-sdk</artifactId>
+							<version>${mock-sdk.version}</version>
+							<outputDirectory>${mock-sdk.location}</outputDirectory>
+							<destFileName>${mock-sdk.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for biosdk-client -->
+						<artifactItem>
+							<groupId>io.mosip.biosdk</groupId>
+							<artifactId>biosdk-client</artifactId>
+							<version>${biosdk-client.version}</version>
+							<outputDirectory>${biosdk-client.location}</outputDirectory>
+							<destFileName>${biosdk-client.fileName}</destFileName>
+							<classifier>jar-with-dependencies</classifier>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for demosdk client -->
+						<artifactItem>
+							<groupId>io.mosip.demosdk</groupId>
+							<artifactId>demosdk</artifactId>
+							<version>${demosdk-client.version}</version>
+							<outputDirectory>${demosdk-client.location}</outputDirectory>
+							<destFileName>${demosdk-client.fileName}</destFileName>
+							<classifier>jar-with-dependencies</classifier>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for image-compressor dependency -->
+						<artifactItem>
+							<groupId>io.mosip.image.compressor</groupId>
+							<artifactId>image-compressor</artifactId>
+							<version>${image-compressor.version}</version>
+							<outputDirectory>${image-compressor.location}</outputDirectory>
+							<destFileName>${image-compressor.fileName}</destFileName>
+							<classifier>jar-with-dependencies</classifier>
+							<type>jar</type>
+						</artifactItem>
+						<artifactItem>
+							<groupId>io.mosip.mock.sdk</groupId>
+							<artifactId>mock-sdk</artifactId>
+							<version>${mock-sdk.version}</version>
+							<outputDirectory>${biosdk-client-lib.location}</outputDirectory>
+							<destFileName>${mock-sdk-dep.fileName}</destFileName>
+							<classifier>jar-with-dependencies</classifier>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for hazelcast-all jar -->
+						<artifactItem>
+							<groupId>com.hazelcast</groupId>
+							<artifactId>hazelcast-all</artifactId>
+							<version>${hazelcast.version}</version>
+							<outputDirectory>${hazelcast.location}</outputDirectory>
+							<destFileName>${hazelcast.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
 
-					<artifactItem>
-						<groupId>io.mosip.esignet</groupId>
-						<version>${esignet-mock-plugin.version}</version>
-						<artifactId>mock-plugin</artifactId>
-						<outputDirectory>${esignet-plugins.location}</outputDirectory>
-						<destFileName>${esignet-mock-plugin.fileName}</destFileName>
-						<type>jar</type>
-					</artifactItem>
-					
-				</artifactItems>
-			<overWriteReleases>true</overWriteReleases>
-              		<overWriteSnapshots>true</overWriteSnapshots>
-              		<overWriteIfNewer>true</overWriteIfNewer>
-            </configuration>
-	  </plugin>
-	</plugins>
-       </build>
+						<!-- artifactItem section for redis-cache jar -->
+						<artifactItem>
+							<groupId>io.mosip.cacheprovider</groupId>
+							<artifactId>cache-provider-redis</artifactId>
+							<version>${redis-cache.version}</version>
+							<outputDirectory>${redis-cache.location}</outputDirectory>
+							<destFileName>${redis-cache.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for esignet authentication wrapper -->
+						<artifactItem>
+							<groupId>io.mosip.esignet.mock</groupId>
+							<artifactId>mock-esignet-integration-impl</artifactId>
+							<version>${esignet-mock-wrapper.version}</version>
+							<outputDirectory>${esignet-wrapper.location}</outputDirectory>
+							<destFileName>${esignet-mock-wrapper.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<artifactItem>
+							<groupId>io.mosip.authentication</groupId>
+							<artifactId>esignet-integration-impl</artifactId>
+							<version>${esignet-ida-wrapper.version}</version>
+							<outputDirectory>${esignet-wrapper.location}</outputDirectory>
+							<destFileName>${esignet-ida-wrapper.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+
+						<artifactItem>
+							<groupId>io.mosip.esignet.sunbirdrc</groupId>
+							<artifactId>sunbird-rc-esignet-integration-impl</artifactId>
+							<version>${esignet-digital-credential-wrapper.version}</version>
+							<outputDirectory>${esignet-wrapper.location}</outputDirectory>
+							<destFileName>${esignet-digital-credential-wrapper.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for certify sunbird plugin -->
+						<artifactItem>
+							<groupId>io.mosip.certify.sunbirdrc</groupId>
+							<artifactId>sunbird-rc-certify-integration-impl</artifactId>
+							<version>${certify-sunbird-plugin.version}</version>
+							<outputDirectory>${certify-plugin.location}</outputDirectory>
+							<destFileName>${certify-sunbird-plugin.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for certify mosip identity plugin -->
+						<artifactItem>
+							<groupId>io.mosip.certify</groupId>
+							<artifactId>mosip-identity-certify-plugin</artifactId>
+							<version>${certify-mosip-identity-plugin.version}</version>
+							<outputDirectory>${certify-plugin.location}</outputDirectory>
+							<destFileName>${certify-mosip-identity-plugin.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+						<!-- artifactItem section for certify mock identity plugin -->
+						<artifactItem>
+							<groupId>io.mosip.certify</groupId>
+							<artifactId>mock-certify-plugin</artifactId>
+							<version>${certify-mock-plugin.version}</version>
+							<outputDirectory>${certify-plugin.location}</outputDirectory>
+							<destFileName>${certify-mock-plugin.fileName}</destFileName>
+							<type>jar</type>
+						</artifactItem>
+					</artifactItems>
+					<overWriteReleases>true</overWriteReleases>
+					<overWriteSnapshots>true</overWriteSnapshots>
+					<overWriteIfNewer>true</overWriteIfNewer>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -171,9 +171,9 @@
 
 		<!-- esignet plugins -->
 		<esignet-plugins.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-plugins</esignet-plugins.location>
-		<esignet-mock-plugin.version>1.4.0-SNAPSHOT</esignet-mock-plugin.version>
+		<esignet-mock-plugin.version>1.3.4</esignet-mock-plugin.version>
 		<esignet-mock-plugin.fileName>esignet-mock-plugin.jar</esignet-mock-plugin.fileName>
-		<mosip-identity-plugin.version>1.4.0-SNAPSHOT</mosip-identity-plugin.version>
+		<mosip-identity-plugin.version>1.3.4</mosip-identity-plugin.version>
 		<mosip-identity-plugin.fileName>mosip-identity-plugin.jar</mosip-identity-plugin.fileName>
 
 		<!-- certify plugins -->

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.artifactory</groupId>
 	<artifactId>artifactory-parent</artifactId>
@@ -34,7 +34,6 @@
 		</developer>
 	</developers>
 
-	<!-- Repo URL verified against released branch (working) - no change needed -->
 	<repositories>
 		<repository>
 			<id>central</id>
@@ -73,95 +72,84 @@
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
 
-		<!-- auth-adapter-lite (kept for backward compatibility) -->
+		<!-- This is auth-adapter-lite dependency and kept for backward compatibility and will be removed in future -->
 		<auth-adapter-lite.version>1.2.0.1-B4</auth-adapter-lite.version>
 		<auth-adapter-lite.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter-lite.location>
 		<auth-adapter-lite.fileName>kernel-auth-adapter-lite.jar</auth-adapter-lite.fileName>
-		
-                <!-- kernel-transliteration-jar -->
-                <kernel-transliteration.version>1.2.0.1</kernel-transliteration.version>
-                <kernel-transliteration.location>/usr/share/nginx/html/artifactory/libs-release-local/icu4j</kernel-transliteration.location>
-                <kernel-transliteration.fileName>kernel-transliteration-icu4j.jar</kernel-transliteration.fileName>
+
+		<!-- kernel-transliteration-jar -->
+		<kernel-transliteration.version>1.2.1-SNAPSHOT</kernel-transliteration.version>
+		<kernel-transliteration.location>/usr/share/nginx/html/artifactory/libs-release-local/icu4j</kernel-transliteration.location>
+		<kernel-transliteration.fileName>kernel-transliteration-icu4j.jar</kernel-transliteration.fileName>
 
 		<!-- kernel-smsserviceprovider-->
 		<kernel-smsserviceprovider.version>1.2.1-SNAPSHOT</kernel-smsserviceprovider.version>
 		<kernel-smsserviceprovider.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</kernel-smsserviceprovider.location>
 		<kernel-smsserviceprovider.fileName>kernel-smsserviceprovider-msg91.jar</kernel-smsserviceprovider.fileName>
-
 		<!-- kernel-ref-idobjectvalidator -->
 		<kernel-ref-idobjectvalidator.version>1.2.1-SNAPSHOT</kernel-ref-idobjectvalidator.version>
 		<kernel-ref-idobjectvalidator.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel/kernel-ref-idobjectvalidator</kernel-ref-idobjectvalidator.location>
 		<kernel-ref-idobjectvalidator.fileName>kernel-ref-idobjectvalidator.jar</kernel-ref-idobjectvalidator.fileName>
-
 		<!-- kernel-virusscanner-clamav -->
 		<kernel-virusscanner-clamav.version>1.2.1-SNAPSHOT</kernel-virusscanner-clamav.version>
 		<kernel-virusscanner-clamav.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav</kernel-virusscanner-clamav.location>
 		<kernel-virusscanner-clamav.fileName>kernel-virusscanner-clamav.jar</kernel-virusscanner-clamav.fileName>
-
 		<!-- registration-api-impl -->
 		<registration-api-impl.version>1.2.1-SNAPSHOT</registration-api-impl.version>
 		<registration-api-impl.location>/usr/share/nginx/html/artifactory/libs-release-local/registration-client/registration-api-impl</registration-api-impl.location>
 		<registration-api-impl.fileName>registration-api-stub-impl.jar</registration-api-impl.fileName>
-		
 		<!-- clamav-client -->
 		<clamav-client.version>1.0.4</clamav-client.version>
 		<clamav-client.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav</clamav-client.location>
 		<clamav-client.fileName>clamav.jar</clamav-client.fileName>
-		
 		<!-- biosdk-client-->
 		<biosdk-client.version>1.2.1-SNAPSHOT</biosdk-client.version>
 		<biosdk-client.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/mock/0.9/biosdk-client</biosdk-client.location>
 		<biosdk-client-lib.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/biosdk-lib</biosdk-client-lib.location>
 		<biosdk-client.fileName>biosdk-client-jar-with-dependencies.jar</biosdk-client.fileName>
-
 		<!-- demosdk-client -->
 		<demosdk-client.version>1.2.1-SNAPSHOT</demosdk-client.version>
 		<demosdk-client.location>/usr/share/nginx/html/artifactory/libs-release-local/demosdk/default/demosdk</demosdk-client.location>
 		<demosdk-client.fileName>demosdk-client-jar-with-dependencies.jar</demosdk-client.fileName>
-		
 		<!-- mock-sdk -->
 		<mock-sdk.version>1.3.0-SNAPSHOT</mock-sdk.version>
 		<mock-sdk.location>/usr/share/nginx/html/artifactory/libs-release-local/mock-sdk/1.1.5</mock-sdk.location>
 		<mock-sdk.fileName>mock-sdk.jar</mock-sdk.fileName>
 		<mock-sdk-dep.fileName>mock-sdk-jar-with-dependencies.jar</mock-sdk-dep.fileName>
-		
 		<!-- image-compressor-->
 		<image-compressor.version>0.0.1-SNAPSHOT</image-compressor.version>
 		<image-compressor.location>/usr/share/nginx/html/artifactory/libs-release-local/compressor/image-compressor</image-compressor.location>
 		<image-compressor.fileName>image-compressor-jar-with-dependencies.jar</image-compressor.fileName>
-		
+
 		<!-- redis-cache -->
 		<redis-cache.version>1.3.1-SNAPSHOT</redis-cache.version>
 		<redis-cache.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</redis-cache.location>
 		<redis-cache.fileName>redis-cache-provider.jar</redis-cache.fileName>
-		
+
 		<!-- hazelcast cast -->
 		<hazelcast.version>3.12.12</hazelcast.version>
 		<hazelcast.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</hazelcast.location>
 		<hazelcast.fileName>cache-provider.jar</hazelcast.fileName>
-		
 		<!-- esignet mock authentication wrapper -->
 		<esignet-wrapper.location>/usr/share/nginx/html/artifactory/libs-release-local/esignet/esignet-wrapper</esignet-wrapper.location>
-		<esignet-mock-wrapper.version>0.9.2</esignet-mock-wrapper.version>
+		<esignet-mock-wrapper.version>0.9.3</esignet-mock-wrapper.version>
 		<esignet-mock-wrapper.fileName>esignet-mock-wrapper.jar</esignet-mock-wrapper.fileName>
-
 		<!-- esignet IDA wrapper -->
 		<esignet-ida-wrapper.version>1.2.0.1</esignet-ida-wrapper.version>
 		<esignet-ida-wrapper.fileName>esignet-ida-wrapper.jar</esignet-ida-wrapper.fileName>
-
 		<!-- esignet sunbird wrapper -->
 		<esignet-digital-credential-wrapper.version>0.2.1</esignet-digital-credential-wrapper.version>
 		<esignet-digital-credential-wrapper.fileName>sunbird-rc-esignet-integration-impl.jar</esignet-digital-credential-wrapper.fileName>
 
 		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
 		<!-- certify sunbird plugin  -->
-		<certify-sunbird-plugin.version>0.3.0</certify-sunbird-plugin.version>
+		<certify-sunbird-plugin.version>0.2.1</certify-sunbird-plugin.version>
 		<certify-sunbird-plugin.fileName>certify-sunbird-plugin.jar</certify-sunbird-plugin.fileName>
 		<!-- certify mosip identity plugin -->
-		<certify-mosip-identity-plugin.version>0.3.0</certify-mosip-identity-plugin.version>
+		<certify-mosip-identity-plugin.version>0.2.1</certify-mosip-identity-plugin.version>
 		<certify-mosip-identity-plugin.fileName>certify-mosip-identity-plugin.jar</certify-mosip-identity-plugin.fileName>
 		<!-- certify mock plugin -->
-		<certify-mock-plugin.version>0.3.0</certify-mock-plugin.version>
+		<certify-mock-plugin.version>0.2.1</certify-mock-plugin.version>
 		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
 	</properties>
 

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -73,14 +73,6 @@
 		<auth-adapter.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter.location>
 		<auth-adapter.fileName>kernel-auth-adapter.jar</auth-adapter.fileName>
 
-		<!--
-			FIX 1: auth-adapter-java-21 properties were referenced in an artifactItem
-			but never declared in <properties>, causing Maven to pass the literal
-			string '${auth-adapter-java-21.version}' as the version → resolution fails.
-		-->
-		<auth-adapter-java-21.version>1.2.1-SNAPSHOT</auth-adapter-java-21.version>
-		<auth-adapter-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/biosdk/mock/0.9/java21</auth-adapter-java-21.location>
-
 		<!-- auth-adapter-lite (kept for backward compatibility) -->
 		<auth-adapter-lite.version>1.2.0.1-B4</auth-adapter-lite.version>
 		<auth-adapter-lite.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</auth-adapter-lite.location>
@@ -105,13 +97,6 @@
 		<kernel-virusscanner-clamav.version>1.2.1-SNAPSHOT</kernel-virusscanner-clamav.version>
 		<kernel-virusscanner-clamav.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav</kernel-virusscanner-clamav.location>
 		<kernel-virusscanner-clamav.fileName>kernel-virusscanner-clamav.jar</kernel-virusscanner-clamav.fileName>
-
-		<!--
-			FIX 2: Same as FIX 1 — kernel-virusscanner-clamav-java-21 properties
-			were used in an artifactItem but never declared here.
-		-->
-		<kernel-virusscanner-clamav-java-21.version>1.2.1-SNAPSHOT</kernel-virusscanner-clamav-java-21.version>
-		<kernel-virusscanner-clamav-java-21.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav/java21</kernel-virusscanner-clamav-java-21.location>
 
 		<!-- registration-api-impl -->
 		<registration-api-impl.version>1.2.1-SNAPSHOT</registration-api-impl.version>
@@ -176,10 +161,12 @@
 		<mosip-identity-plugin.version>1.4.0-SNAPSHOT</mosip-identity-plugin.version>
 		<mosip-identity-plugin.fileName>mosip-identity-plugin.jar</mosip-identity-plugin.fileName>
 
-		<!-- certify plugins -->
+		<!-- certify mosip identity plugin -->
 		<certify-plugin.location>/usr/share/nginx/html/artifactory/libs-release-local/certify/certify-plugin</certify-plugin.location>
 		<certify-mosip-identity-plugin.version>0.3.0</certify-mosip-identity-plugin.version>
 		<certify-mosip-identity-plugin.fileName>certify-mosip-identity-plugin.jar</certify-mosip-identity-plugin.fileName>
+
+		<!-- certify mock plugin -->
 		<certify-mock-plugin.version>0.3.0</certify-mock-plugin.version>
 		<certify-mock-plugin.fileName>certify-mock-identity-plugin.jar</certify-mock-plugin.fileName>
 		<certify-sunbird-plugin.version>0.3.0</certify-sunbird-plugin.version>

--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -146,7 +146,7 @@
 		<image-compressor.fileName>image-compressor-jar-with-dependencies.jar</image-compressor.fileName>
 		
 		<!-- redis-cache -->
-		<redis-cache.version>1.3.0-SNAPSHOT</redis-cache.version>
+		<redis-cache.version>1.3.1-SNAPSHOT</redis-cache.version>
 		<redis-cache.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</redis-cache.location>
 		<redis-cache.fileName>redis-cache-provider.jar</redis-cache.fileName>
 		


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Maven in the build environment to a newer patch release.
  * Removed obsolete Java 21-specific build variants and related artifacts to simplify and slim down build outputs.
  * Revised repository and distribution endpoints and snapshot settings to streamline publishing and deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->