### PR TITLE
[MOSIP-44947] Updated the Maven version to 3.9.16 in Dockerfile

### DIFF
--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -28,10 +28,10 @@ apt-get update -y && \
 apt-get install -y --no-install-recommends unzip wget zip openjdk-11-jdk && \
 groupadd -g ${container_user_gid} ${container_user_group} &&\
 rm -rf /var/lib/apt/lists/* &&\
-wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz && \
-tar -xzf apache-maven-3.9.15-bin.tar.gz && \
-mv apache-maven-3.9.15 /usr/local/maven && \
-rm apache-maven-3.9.15-bin.tar.gz && \
+wget https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz && \
+tar -xzf apache-maven-3.9.16-bin.tar.gz && \
+mv apache-maven-3.9.16 /usr/local/maven && \
+rm apache-maven-3.9.16-bin.tar.gz && \
 useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
 && mkdir -p /var/run/nginx /var/tmp/nginx \
 && chown -R ${container_user}:${container_user} /usr/share/nginx /var/run/nginx /var/tmp/nginx


### PR DESCRIPTION
[MOSIP-44947] Updated the Maven version to 3.9.16 in Dockerfile

[MOSIP-44947]: https://mosip.atlassian.net/browse/MOSIP-44947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ