### PR TITLE
#2384: Update POM, helm chart and install script versions for 1.3.2 release

### DIFF
--- a/artifacts/pom.xml
+++ b/artifacts/pom.xml
@@ -78,20 +78,20 @@
 		<auth-adapter-lite.fileName>kernel-auth-adapter-lite.jar</auth-adapter-lite.fileName>
 
 		<!-- kernel-transliteration-jar -->
-		<kernel-transliteration.version>1.3.1-rc.1</kernel-transliteration.version>
+		<kernel-transliteration.version>1.3.1-SNAPSHOT</kernel-transliteration.version>
 		<kernel-transliteration.location>/usr/share/nginx/html/artifactory/libs-release-local/icu4j</kernel-transliteration.location>
 		<kernel-transliteration.fileName>kernel-transliteration-icu4j.jar</kernel-transliteration.fileName>
 
 		<!-- kernel-smsserviceprovider-->
-		<kernel-smsserviceprovider.version>1.3.1-rc.1</kernel-smsserviceprovider.version>
+		<kernel-smsserviceprovider.version>1.3.1-SNAPSHOT</kernel-smsserviceprovider.version>
 		<kernel-smsserviceprovider.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel</kernel-smsserviceprovider.location>
 		<kernel-smsserviceprovider.fileName>kernel-smsserviceprovider-msg91.jar</kernel-smsserviceprovider.fileName>
 		<!-- kernel-ref-idobjectvalidator -->
-		<kernel-ref-idobjectvalidator.version>1.3.1-rc.1</kernel-ref-idobjectvalidator.version>
+		<kernel-ref-idobjectvalidator.version>1.3.1-SNAPSHOT</kernel-ref-idobjectvalidator.version>
 		<kernel-ref-idobjectvalidator.location>/usr/share/nginx/html/artifactory/libs-release-local/io/mosip/kernel/kernel-ref-idobjectvalidator</kernel-ref-idobjectvalidator.location>
 		<kernel-ref-idobjectvalidator.fileName>kernel-ref-idobjectvalidator.jar</kernel-ref-idobjectvalidator.fileName>
 		<!-- kernel-virusscanner-clamav -->
-		<kernel-virusscanner-clamav.version>1.3.1-rc.1</kernel-virusscanner-clamav.version>
+		<kernel-virusscanner-clamav.version>1.3.1-SNAPSHOT</kernel-virusscanner-clamav.version>
 		<kernel-virusscanner-clamav.location>/usr/share/nginx/html/artifactory/libs-release-local/clamav</kernel-virusscanner-clamav.location>
 		<kernel-virusscanner-clamav.fileName>kernel-virusscanner-clamav.jar</kernel-virusscanner-clamav.fileName>
 		<!-- registration-api-impl -->
@@ -112,7 +112,7 @@
 		<demosdk-client.location>/usr/share/nginx/html/artifactory/libs-release-local/demosdk/default/demosdk</demosdk-client.location>
 		<demosdk-client.fileName>demosdk-client-jar-with-dependencies.jar</demosdk-client.fileName>
 		<!-- mock-sdk -->
-		<mock-sdk.version>1.3.1-rc.1</mock-sdk.version>
+		<mock-sdk.version>1.3.1-SNAPSHOT</mock-sdk.version>
 		<mock-sdk.location>/usr/share/nginx/html/artifactory/libs-release-local/mock-sdk/1.1.5</mock-sdk.location>
 		<mock-sdk.fileName>mock-sdk.jar</mock-sdk.fileName>
 		<mock-sdk-dep.fileName>mock-sdk-jar-with-dependencies.jar</mock-sdk-dep.fileName>
@@ -122,7 +122,7 @@
 		<image-compressor.fileName>image-compressor-jar-with-dependencies.jar</image-compressor.fileName>
 
 		<!-- redis-cache -->
-		<redis-cache.version>1.3.1-rc.1</redis-cache.version>
+		<redis-cache.version>1.3.1-SNAPSHOT</redis-cache.version>
 		<redis-cache.location>/usr/share/nginx/html/artifactory/libs-release-local/cache</redis-cache.location>
 		<redis-cache.fileName>redis-cache-provider.jar</redis-cache.fileName>
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=artifactory
-CHART_VERSION=1.3.2-rc.1-develop
+CHART_VERSION=1.3.2-develop
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/helm/artifactory/Chart.yaml
+++ b/helm/artifactory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifactory
 description: A Helm chart for MOSIP Artifactory
 type: application
-version: 1.3.2-rc.1-develop
+version: 1.3.2-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/artifactory/values.yaml
+++ b/helm/artifactory/values.yaml
@@ -46,8 +46,8 @@ service:
 ## with biosdk 'develop' version.  TODO: Change this later
 image:
   registry: docker.io
-  repository: mosipid/artifactory-server
-  tag: 1.3.2-rc.1
+  repository: mosipqa/artifactory-server
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Convert rc versions to SNAPSHOT in artifacts/pom.xml, update Chart.yaml and install.sh chart_version to 1.3.2-develop, and point values.yaml image repository to mosipqa with tag 1.3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component versions to the 1.3.1 snapshot release line.
  * Updated the Artifactory deployment and chart to the 1.3.2 development release line.
  * Switched the Artifactory container image source and updated its image tag to the 1.3.x series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->